### PR TITLE
Fix navigation links in About page to use proper routes

### DIFF
--- a/client/pages/About.tsx
+++ b/client/pages/About.tsx
@@ -117,10 +117,10 @@ export default function About() {
               <div className="container mx-auto px-4 py-4 space-y-4">
                 {[
                   { name: "Home", href: "/" },
-                  { name: "Services", href: "/#services" },
+                  { name: "Services", href: "/services" },
                   { name: "About", href: "/about" },
                   { name: "Sales", href: "/sales" },
-                  { name: "Contact", href: "/#contact" },
+                  { name: "Contact", href: "/contact" },
                 ].map((item, index) => (
                   <motion.a
                     key={item.name}

--- a/client/pages/About.tsx
+++ b/client/pages/About.tsx
@@ -65,10 +65,10 @@ export default function About() {
           <div className="hidden md:flex space-x-8">
             {[
               { name: "Home", href: "/" },
-              { name: "Services", href: "/#services" },
+              { name: "Services", href: "/services" },
               { name: "About", href: "/about" },
               { name: "Sales", href: "/sales" },
-              { name: "Contact", href: "/#contact" },
+              { name: "Contact", href: "/contact" },
             ].map((item, index) => (
               <motion.a
                 key={item.name}


### PR DESCRIPTION
## Purpose
Fix navigation issue where clicking on Contact and Services links from the About page incorrectly redirected users to the home page instead of their intended destinations.

## Code changes
Updated navigation links in About.tsx component:
- Changed Services link from `/#services` to `/services` 
- Changed Contact link from `/#contact` to `/contact`
- Applied fixes to both desktop and mobile navigation menus

This ensures proper routing to dedicated pages rather than hash-based navigation that was causing the redirect issues.

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/app/projects/7bee6e8dcba64e0c9481d6eaedb7cec9/cosmos-field)

👀 [Preview Link](https://7bee6e8dcba64e0c9481d6eaedb7cec9-cosmos-field.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>7bee6e8dcba64e0c9481d6eaedb7cec9</projectId>-->
<!--<branchName>cosmos-field</branchName>-->